### PR TITLE
Sanitized input to hexToRGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This extension hopes to clean the HTML that Adobe Edge Reflow makes in order to provide a better starting spot for hand coded projects.
 
+## Author
+The author of this extension is Terrence Ryan (https://github.com/tpryan). I merely added a workaround to get the CSS extractor to work again with a new version of Brackets/Adobe Edge Code CC.
+
 ## Abilities 
 Currently the project does the following:
 

--- a/reflowCSSExtractor.js
+++ b/reflowCSSExtractor.js
@@ -741,6 +741,9 @@ var ReflowCSSExtractor = function (csscontent) {
 	};
 
 	this.hexToRGB = function (hex) {
+	    if (hex == null) {
+	    	return {r: 0, g:0, b:0};
+	    }
 	    // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
 	    var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
 	    hex = hex.replace(shorthandRegex, function (m, r, g, b) {


### PR DESCRIPTION
CSS extractor broke in hexToRGB due to variable hex being undefined. I "fixed" this by returning an object encoding black if the input is null. This may lead to unexpected side effects, but the extractor is working again.
For a full explanation see https://github.com/tpryan/Brackets-Reflow-Cleaner/issues/3
